### PR TITLE
Adiciona `--rm` ao `docker-compose run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Fabdeploy
 
-
 Para instalar use:
 
 ```
 pip install -e git+git@github.com:sisqualis/fabdeploy.git#egg=fabdeploy
 ```
+
+## Requisitos
+
+Requer Docker Compose `>= 1.3.0` na máquina onde o deploy está sendo executado.

--- a/fabdeploy/tasks.py
+++ b/fabdeploy/tasks.py
@@ -105,7 +105,7 @@ class Deploy(RemoteTask):
 
     def update_app(self):
         for cmd in self.commands:
-            run('docker-compose -f {manifest} run {container} {command}'.format(command=cmd, container=self.container, manifest=self.manifest))
+            run('docker-compose -f {manifest} run --rm {container} {command}'.format(command=cmd, container=self.container, manifest=self.manifest))
         run('docker-compose -f {manifest} up -d'.format(manifest=self.manifest))
 
 


### PR DESCRIPTION
Isto evita que containers fiquei reiniciando indefinidamente após um
comando que deve ser executado apenas uma vez.

[Requer versão `>= 1.3.0` do Docker Compose][1].

[1]: https://github.com/docker/compose/blob/d7db15ce9452c765828f585cad06b46282d54a33/CHANGELOG.md#130-2015-06-18